### PR TITLE
[#4] Router.addRoute 단일 파라미터 라우트 저장 지원

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,15 +1,16 @@
 import "./styles/reset.css";
-import { createRouter } from "./router";
 import Sidebar from "./components/Sidebar/index.js";
+import { createRouter } from "./router.js";
 
-// Sidebar 더미 데이터
 export default function App() {
+  const router = createRouter();
+
   const main = document.createElement("main");
-
-  const aside = document.createElement("aside");
-  aside.innerText = "aside";
-
   main.appendChild(Sidebar());
+
+  router.addRoute("/", "emptyPage");
+  router.addRoute("/documents", "emptyPage");
+  router.addRoute("/documents/:id", main);
 
   return main;
 }

--- a/src/router.js
+++ b/src/router.js
@@ -1,12 +1,18 @@
 export function createRouter() {
   const routes = {};
-  let currentRoute = null;
 
   return {
     addRoute: (path, page) => {
-      routes[path] = page;
-      currentRoute = routes[path];
+      let param = null;
+
+      const parsedPath = path.replace(/:(\w+)/, (_, paramName) => {
+        param = paramName;
+        return "([^/]+)";
+      });
+
+      const regex = new RegExp(`^${parsedPath}$`);
+
+      routes[path] = { regex, page, param };
     },
-    getCurrentRoute: () => currentRoute,
   };
 }


### PR DESCRIPTION
## 개요

이슈 번호: #4 

엔드포인트에 `documents/:id` 단일 파라미터를 정규식으로 변환하여 추출 후 저장

## 작업 내용

- [x] 정규식을 이용해 path에서 id를 추출할 수 있도록 구현
- [x] path와 해당 path의 page를 routes에 저장하도록 구현
- [x] `/documents/:id` → 정규식: `^/documents/([^/]+)$` 치환으로 파라미터를 일관적으로 추출

## 기타

🫠