### PR TITLE
[#10] sidebar API 토글 기능 구현

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,12 +3,16 @@ import Sidebar from "./components/Sidebar/index.js";
 import { createRouter } from "./router.js";
 import Editor from "./components/Editor/index.js";
 
-export default function App() {
+export default async function App() {
   const router = createRouter();
 
   const main = document.createElement("main");
+<<<<<<< HEAD
   main.appendChild(Sidebar());
   main.appendChild(Editor());
+=======
+  main.appendChild(await Sidebar());
+>>>>>>> a8becbf (이벤트 리스너를 이벤트 위임 형식으로 변경하고 sidebarEl에 적용)
 
   router.addRoute("/", "empty");
   router.addRoute("/documents", "empty");

--- a/src/App.js
+++ b/src/App.js
@@ -7,19 +7,10 @@ export default function App() {
   const router = createRouter();
 
   const main = document.createElement("main");
-<<<<<<< HEAD
-<<<<<<< HEAD
-  main.appendChild(Sidebar());
-  main.appendChild(Editor());
-=======
-  main.appendChild(await Sidebar());
->>>>>>> a8becbf (이벤트 리스너를 이벤트 위임 형식으로 변경하고 sidebarEl에 적용)
-=======
   Sidebar().then((sidebarEl) => {
     main.appendChild(sidebarEl);
   });
-  // main.appendChild(Sidebar());
->>>>>>> dae8d51 (App.js에서 then을 이용하여 promise 반환값 처리)
+  main.appendChild(Editor());
 
   router.addRoute("/", "empty");
   router.addRoute("/documents", "empty");

--- a/src/App.js
+++ b/src/App.js
@@ -3,16 +3,23 @@ import Sidebar from "./components/Sidebar/index.js";
 import { createRouter } from "./router.js";
 import Editor from "./components/Editor/index.js";
 
-export default async function App() {
+export default function App() {
   const router = createRouter();
 
   const main = document.createElement("main");
+<<<<<<< HEAD
 <<<<<<< HEAD
   main.appendChild(Sidebar());
   main.appendChild(Editor());
 =======
   main.appendChild(await Sidebar());
 >>>>>>> a8becbf (이벤트 리스너를 이벤트 위임 형식으로 변경하고 sidebarEl에 적용)
+=======
+  Sidebar().then((sidebarEl) => {
+    main.appendChild(sidebarEl);
+  });
+  // main.appendChild(Sidebar());
+>>>>>>> dae8d51 (App.js에서 then을 이용하여 promise 반환값 처리)
 
   router.addRoute("/", "empty");
   router.addRoute("/documents", "empty");

--- a/src/api/documents.js
+++ b/src/api/documents.js
@@ -9,10 +9,11 @@ const getList = () => http.get(BASE_URL, HEADERS);
 
 const get = () => {};
 
-const create = () => {};
+const create = ({ title = "새 페이지", parent = null }) =>
+  http.post(BASE_URL, HEADERS, { title, parent });
 
 const update = () => {};
 
-const del = () => http.del(BASE_URL, HEADERS);
+const del = (id) => http.delete(`${BASE_URL}/${id}`, HEADERS);
 
 export default { getList, get, create, update, del };

--- a/src/api/documents.js
+++ b/src/api/documents.js
@@ -13,6 +13,6 @@ const create = () => {};
 
 const update = () => {};
 
-const del = () => {};
+const del = () => http.del(BASE_URL, HEADERS);
 
 export default { getList, get, create, update, del };

--- a/src/components/Sidebar/index.js
+++ b/src/components/Sidebar/index.js
@@ -33,7 +33,7 @@ const createDocumentItem = (doc) => {
   const rightToggleArea = document.createElement("div");
   rightToggleArea.className = "right-toggle-area";
 
-  // 헤더 영역 제목 생성
+  // 페이지 제목 생성
   const pageLink = document.createElement("a");
   pageLink.href = `/documents/${doc.id}`;
   const pageTitle = document.createElement("span");
@@ -113,7 +113,7 @@ const Sidebar = async () => {
   sidebarEl.appendChild(sidebarHeader);
   sidebarEl.appendChild(documentListNav);
 
-  // 이벤트리스너(이벤트 위임) sidebarEl에 붙힘
+  // 이벤트리스너(이벤트 위임)
   sidebarEl.addEventListener("click", async (e) => {
     const target = e.target;
     // 접기/펴기 토글 버튼
@@ -138,8 +138,9 @@ const Sidebar = async () => {
           target.textContent = "▼";
         }
       }
-    } else if (target.classList.contains("add-child-button")) {
-      // '+' 버튼 클릭
+    }
+    // '+' 버튼 클릭
+    else if (target.classList.contains("add-child-button")) {
       const parentLi = target.closest(".document-item");
       const parentId = parentLi ? parentLi.dataset.id : null;
       try {
@@ -152,11 +153,36 @@ const Sidebar = async () => {
         renderDocuments(documentListNav, updatedDocuments);
         // 모든 문서 최하단에 [새 페이지 추가] 버튼
         documentListNav.appendChild(BottomAddPageButton);
+
+        // 하위 문서가 보이도록 ul 태그의 hidden 클래스 제거
+        let currentLi = documentListNav.querySelector(`[data-id="${parentId}"]`);
+        if (currentLi) {
+          // 부모 문서부터 상위 노드까지 순회하며 hidden 클래스 제거
+          while (currentLi && currentLi.classList.contains("document-item")) {
+            const childDocsUl = currentLi.querySelector("ul");
+            if (childDocsUl) {
+              childDocsUl.classList.remove("hidden");
+              const toggleButton = currentLi.querySelector(".toggle-button");
+              if (toggleButton) {
+                toggleButton.textContent = "▼";
+              }
+            }
+
+            // 다음 부모 문서로 이동
+            const parentUl = currentLi.parentElement;
+            if (parentUl && parentUl.classList.contains("document-list")) {
+              currentLi = parentUl.closest(".document-item");
+            } else {
+              currentLi = null;
+            }
+          }
+        }
       } catch (error) {
         console.error("문서 생성 중 오류", error);
       }
-    } else if (target.classList.contains("delete-button")) {
-      // '휴지통' 버튼 클릭
+    }
+    // '휴지통' 버튼 클릭
+    else if (target.classList.contains("delete-button")) {
       const parentLi = target.closest(".document-item");
       const documentId = parentLi ? parentLi.dataset.id : null;
       if (documentId) {
@@ -167,8 +193,9 @@ const Sidebar = async () => {
           console.error("문서 삭제 중 오류 발생:", error);
         }
       }
-    } else if (target.closest(".bottom-add-page-area")) {
-      // 최하단 '새 페이지 추가' 버튼 클릭
+    }
+    // 최하단 '새 페이지 추가' 버튼 클릭
+    else if (target.closest(".bottom-add-page-area")) {
       try {
         await apiDocs.create({});
         const updatedDocuments = await apiDocs.getList(); // 기존 문서 목록을 비우고 새로운 문서 목록으로 다시 렌더링

--- a/src/components/Sidebar/index.js
+++ b/src/components/Sidebar/index.js
@@ -1,6 +1,7 @@
 import "./style.css";
 import apiDocs from "../../api/documents";
 
+// 하단 새 페이지 추가 버튼 생성
 const createAddPageButton = () => {
   const addPageButtonArea = document.createElement("div");
   addPageButtonArea.className = "bottom-add-page-area";
@@ -101,6 +102,7 @@ const Sidebar = async () => {
     parent.appendChild(ul);
   };
 
+  // API 호출 및 렌더링
   const documents = await apiDocs.getList();
   renderDocuments(documentListNav, documents); // 재귀 호출, 하위 문서 있으면 렌더링
 

--- a/src/components/Sidebar/index.js
+++ b/src/components/Sidebar/index.js
@@ -41,6 +41,8 @@ const Sidebar = async () => {
       // 문서DOM 구조 생성
       const li = document.createElement("li");
       li.className = "document-item";
+      li.dataset.id = doc.id;
+      li.dataset.parent = doc.documents;
 
       const pageInfo = document.createElement("div");
       pageInfo.className = "page-info";
@@ -68,17 +70,17 @@ const Sidebar = async () => {
       toggleButton.textContent = "▶";
       leftToggleArea.appendChild(toggleButton);
 
-      // 새 문서 추가
-      const addButton = document.createElement("span");
-      addButton.className = "add-child-button";
-      addButton.textContent = "+";
-      rightToggleArea.appendChild(addButton);
-
       // 휴지통
       const deleteButton = document.createElement("span");
       deleteButton.className = "delete-button";
       deleteButton.textContent = "🗑️";
       rightToggleArea.appendChild(deleteButton);
+
+      // 새 문서 추가
+      const addButton = document.createElement("span");
+      addButton.className = "add-child-button";
+      addButton.textContent = "+";
+      rightToggleArea.appendChild(addButton);
 
       // <div>
       pageInfo.appendChild(leftToggleArea);
@@ -115,7 +117,7 @@ const Sidebar = async () => {
   sidebarEl.appendChild(documentListNav);
 
   // 이벤트리스너(이벤트 위임) sidebarEl에 붙힘
-  sidebarEl.addEventListener("click", (e) => {
+  sidebarEl.addEventListener("click", async (e) => {
     const target = e.target;
     // 접기/펴기 토글 버튼
     if (target.classList.contains("toggle-button")) {
@@ -143,12 +145,34 @@ const Sidebar = async () => {
       // '+' 버튼 클릭
       const parentLi = target.closest(".document-item");
       const parentId = parentLi ? parentLi.dataset.id : null;
+      try {
+        await apiDocs.create({ parent: parentId });
+        const updatedDocuments = await apiDocs.getList();
+        // 기존 문서 목록을 비우고 새로운 문서 목록으로 다시 렌더링
+        const documentListNav = document.getElementById("document-list");
+        documentListNav.innerHTML = "";
+        renderDocuments(documentListNav, updatedDocuments);
+      } catch (error) {
+        console.error("문서 생성 중 오류", error);
+      }
+
       console.log("추가");
     } else if (target.classList.contains("delete-button")) {
       // '휴지통' 버튼 클릭
       const parentLi = target.closest(".document-item");
       const documentId = parentLi ? parentLi.dataset.id : null;
-      console.log("삭제");
+      try {
+        await apiDocs.del(documentId);
+        const updatedDocuments = await apiDocs.getList();
+
+        // 기존 문서 목록을 비우고 새로운 문서 목록으로 다시 렌더링
+        const documentListNav = document.getElementById("document-list");
+        documentListNav.innerHTML = "";
+        renderDocuments(documentListNav, updatedDocuments);
+      } catch (error) {
+        console.error("문서 삭제 중 오류 발생:", error);
+        console.log("삭제");
+      }
     }
   });
 

--- a/src/components/Sidebar/index.js
+++ b/src/components/Sidebar/index.js
@@ -18,6 +18,53 @@ const createAddPageButton = () => {
   return addPageButtonArea;
 };
 
+// 개별 문서(li) 항목을 생성하는 함수
+const createDocumentItem = (doc) => {
+  const li = document.createElement("li"); // <li>
+  li.className = "document-item";
+  li.dataset.id = doc.id;
+
+  const pageInfo = document.createElement("div");
+  pageInfo.className = "page-info";
+
+  // 좌측, 우측 토글 영역 생성
+  const leftToggleArea = document.createElement("div");
+  leftToggleArea.className = "left-toggle-area";
+  const rightToggleArea = document.createElement("div");
+  rightToggleArea.className = "right-toggle-area";
+
+  // 헤더 영역 제목 생성
+  const pageLink = document.createElement("a");
+  pageLink.href = `/documents/${doc.id}`;
+  const pageTitle = document.createElement("span");
+  pageTitle.className = "page-title";
+  pageTitle.textContent = doc.title;
+  pageLink.appendChild(pageTitle);
+
+  // 버튼 요소 생성
+  const toggleButton = document.createElement("span");
+  toggleButton.className = "toggle-button";
+  toggleButton.textContent = "▶";
+  const deleteButton = document.createElement("span");
+  deleteButton.className = "delete-button";
+  deleteButton.textContent = "🗑️";
+  const addButton = document.createElement("span");
+  addButton.className = "add-child-button";
+  addButton.textContent = "+";
+
+  leftToggleArea.appendChild(toggleButton);
+  rightToggleArea.appendChild(deleteButton);
+  rightToggleArea.appendChild(addButton);
+
+  pageInfo.appendChild(leftToggleArea);
+  pageInfo.appendChild(pageTitle);
+  pageInfo.appendChild(rightToggleArea);
+
+  li.appendChild(pageInfo); // </li>
+
+  return li;
+};
+
 const Sidebar = async () => {
   /* 사이드바 기본 구조 생성 */
   // 사이드바 전체를 감싸는 aside 생성
@@ -27,6 +74,9 @@ const Sidebar = async () => {
   // 사이드바 헤더 영역
   const sidebarHeader = document.createElement("div");
   sidebarHeader.className = "sidebar-header";
+  const userNameText = document.createElement("span");
+  userNameText.textContent = `Update의 Notion`;
+  userNameText.className = "user-name";
 
   // 문서 목록을 담을 네비게이션 영역
   const documentListNav = document.createElement("nav");
@@ -38,81 +88,28 @@ const Sidebar = async () => {
     ul.className = "document-list";
 
     docs.forEach((doc) => {
-      // 문서DOM 구조 생성
-      const li = document.createElement("li");
-      li.className = "document-item";
-      li.dataset.id = doc.id;
-      li.dataset.parent = doc.documents;
-
-      const pageInfo = document.createElement("div");
-      pageInfo.className = "page-info";
-
-      // 문서 제목 영역
-      const pageTitleArea = document.createElement("div");
-      pageTitleArea.className = "page-title-area";
-
-      // 좌측, 우측 토글 아이콘 영역
-      const leftToggleArea = document.createElement("div");
-      leftToggleArea.className = "left-toggle-area";
-
-      const rightToggleArea = document.createElement("div");
-      rightToggleArea.className = "right-toggle-area";
-
-      // 문서 제목
-      const pageTitle = document.createElement("span");
-      pageTitle.className = "page-title";
-      pageTitle.textContent = doc.title;
-      pageTitleArea.appendChild(pageTitle);
-
-      // 접기/펴기
-      const toggleButton = document.createElement("span");
-      toggleButton.className = "toggle-button";
-      toggleButton.textContent = "▶";
-      leftToggleArea.appendChild(toggleButton);
-
-      // 휴지통
-      const deleteButton = document.createElement("span");
-      deleteButton.className = "delete-button";
-      deleteButton.textContent = "🗑️";
-      rightToggleArea.appendChild(deleteButton);
-
-      // 새 문서 추가
-      const addButton = document.createElement("span");
-      addButton.className = "add-child-button";
-      addButton.textContent = "+";
-      rightToggleArea.appendChild(addButton);
-
-      // <div>
-      pageInfo.appendChild(leftToggleArea);
-      pageInfo.appendChild(pageTitle);
-      pageInfo.appendChild(rightToggleArea);
-
-      // <div>
-      li.appendChild(pageInfo);
-
-      // 하위 문서 있으면 기본으로 닫음 상태로 전환
+      const li = createDocumentItem(doc);
+      // 하위 문서 있으면 재귀 호출
       if (doc.documents && doc.documents.length > 0) {
         renderDocuments(li, doc.documents);
         li.querySelector("ul").classList.add("hidden");
       }
 
-      // <li>
       ul.appendChild(li);
     });
-
-    // <ul>
     parent.appendChild(ul);
   };
-
   // API 호출 및 렌더링
   const documents = await apiDocs.getList();
+  console.log(documents);
   renderDocuments(documentListNav, documents); // 재귀 호출, 하위 문서 있으면 렌더링
 
-  // 모든 문서 최하단에 [새 페이지 추가] 버튼
+  // 모든 문서의 최하단에 [새 페이지 추가] 버튼
   const BottomAddPageButton = createAddPageButton();
   documentListNav.appendChild(BottomAddPageButton);
 
   /* 렌더링 결과물 추가 */
+  sidebarHeader.appendChild(userNameText);
   sidebarEl.appendChild(sidebarHeader);
   sidebarEl.appendChild(documentListNav);
 
@@ -148,30 +145,40 @@ const Sidebar = async () => {
       try {
         await apiDocs.create({ parent: parentId });
         const updatedDocuments = await apiDocs.getList();
+
         // 기존 문서 목록을 비우고 새로운 문서 목록으로 다시 렌더링
         const documentListNav = document.getElementById("document-list");
         documentListNav.innerHTML = "";
         renderDocuments(documentListNav, updatedDocuments);
+        // 모든 문서 최하단에 [새 페이지 추가] 버튼
+        documentListNav.appendChild(BottomAddPageButton);
       } catch (error) {
         console.error("문서 생성 중 오류", error);
       }
-
-      console.log("추가");
     } else if (target.classList.contains("delete-button")) {
       // '휴지통' 버튼 클릭
       const parentLi = target.closest(".document-item");
       const documentId = parentLi ? parentLi.dataset.id : null;
+      if (documentId) {
+        try {
+          await apiDocs.del(documentId);
+          parentLi.remove();
+        } catch (error) {
+          console.error("문서 삭제 중 오류 발생:", error);
+        }
+      }
+    } else if (target.closest(".bottom-add-page-area")) {
+      // 최하단 '새 페이지 추가' 버튼 클릭
       try {
-        await apiDocs.del(documentId);
-        const updatedDocuments = await apiDocs.getList();
+        await apiDocs.create({});
+        const updatedDocuments = await apiDocs.getList(); // 기존 문서 목록을 비우고 새로운 문서 목록으로 다시 렌더링
 
-        // 기존 문서 목록을 비우고 새로운 문서 목록으로 다시 렌더링
         const documentListNav = document.getElementById("document-list");
         documentListNav.innerHTML = "";
         renderDocuments(documentListNav, updatedDocuments);
+        documentListNav.appendChild(BottomAddPageButton);
       } catch (error) {
-        console.error("문서 삭제 중 오류 발생:", error);
-        console.log("삭제");
+        console.error("루트 문서 생성 중 오류 발생:", error);
       }
     }
   });

--- a/src/components/Sidebar/index.js
+++ b/src/components/Sidebar/index.js
@@ -33,6 +33,10 @@ const createDocumentItem = (doc) => {
   const rightToggleArea = document.createElement("div");
   rightToggleArea.className = "right-toggle-area";
 
+  // 페이지 제목 영역 생성
+  const pageTitleArea = document.createElement("div");
+  pageTitleArea.className = "page-title-area";
+
   // 페이지 제목 생성
   const pageLink = document.createElement("a");
   pageLink.href = `/documents/${doc.id}`;
@@ -40,6 +44,7 @@ const createDocumentItem = (doc) => {
   pageTitle.className = "page-title";
   pageTitle.textContent = doc.title;
   pageLink.appendChild(pageTitle);
+  pageTitleArea.appendChild(pageLink);
 
   // 버튼 요소 생성
   const toggleButton = document.createElement("span");
@@ -57,9 +62,8 @@ const createDocumentItem = (doc) => {
   rightToggleArea.appendChild(addButton);
 
   pageInfo.appendChild(leftToggleArea);
-  pageInfo.appendChild(pageTitle);
+  pageInfo.appendChild(pageTitleArea);
   pageInfo.appendChild(rightToggleArea);
-
   li.appendChild(pageInfo); // </li>
 
   return li;

--- a/src/components/Sidebar/style.css
+++ b/src/components/Sidebar/style.css
@@ -2,8 +2,8 @@
   width: 240px;
   min-width: 240px;
   height: 100vh;
-  background-color: #f7f6f3; /* 노션 기본 배경색 */
-  border-right: 1px solid #e0e0e0;
+  background-color: #f9f8f7; /* 노션 기본 배경색 */
+  border-right: 1px solid #e0e0e0a5;
   padding: 12px 0 0;
   display: flex;
   flex-direction: column;
@@ -50,6 +50,7 @@
   display: none;
 }
 
+/* 왼쪽 토글 영역 */
 .left-toggle-area {
   width: 20px;
   height: 20px;

--- a/src/components/Sidebar/style.css
+++ b/src/components/Sidebar/style.css
@@ -75,6 +75,20 @@
   text-overflow: ellipsis;
 }
 
+/* 페이지 제목 영역을 확장하여 오른쪽 버튼을 밀어내기 */
+.page-title-area {
+  flex-grow: 1; /* 이 속성을 추가하여 남은 공간을 모두 차지하도록 함 */
+  overflow: hidden;
+  display: flex;
+}
+
+.page-title-area a {
+  text-decoration: none;
+  color: inherit;
+  flex-grow: 1;
+  overflow: hidden;
+}
+
 /* 오른쪽 토글 영역 */
 .right-toggle-area {
   display: flex;

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,10 @@
 import App from "./App";
 import "./styles/styles.css";
 
-export default async function render(app) {
+export default function render(app) {
   const root = document.getElementById("root");
 
-  root?.replaceChildren(await app());
+  root?.replaceChildren(app());
 }
 
 render(App);

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,10 @@
 import App from "./App";
 import "./styles/styles.css";
 
-export default function render(app) {
+export default async function render(app) {
   const root = document.getElementById("root");
 
-  root?.replaceChildren(app());
+  root?.replaceChildren(await app());
 }
 
 render(App);


### PR DESCRIPTION
## 개요

이슈 번호: #10 

<!-- 해당 #PR의 간단한 요약 및 관련 이슈 링크 -->

## 작업 내용

<!-- 해당 PR에서 작업한 상세 내역 -->
- Sidebar/index.js
- [x] 문서 이름 좌측 접기/펴기 기능 토글
  -  하위 문서가 없는 경우, 펼치기 시 "하위페이지 없음" 문구 표시
- [x] 문서 이름 우측 [+] 토글 (API)
  -  해당 버튼을 클릭하면, 클릭한 Document의 하위 Document로 새 Document를 생성하고 편집화면으로 넘깁니다.
  - 해당 버튼을 클릭하면 문서를 펼칩니다. (부모 요소를 순회하면서)
- [x] 문서 이름 우측 [삭제] 토글 (API)
  -  해당 버튼 클릭하면, 해당 문서를 삭제
- [x] ul 영역 생성 기능을 함수로 분리
- [x] 문서 제목에 a 태그 추가
  -  문서의 a 태그에 href 연결
  
- App.js
- [x] promise를 리턴하는 sidebar를 then을 이용해서 받음



## 기타

<!-- 기타 작성해야 할 내용 -->
